### PR TITLE
Update PostgreSQL client handling and add entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM debian:bookworm-slim
 
 # Set default PostgreSQL client version if not specified
-ARG POSTGRESQL_CLIENT_VERSION=17
-ENV POSTGRESQL_CLIENT_VERSION=${POSTGRESQL_CLIENT_VERSION}
+ENV POSTGRESQL_CLIENT_VERSION=15
 
 # Install all packages in a single RUN command
 RUN apt update && apt install -y \
@@ -16,7 +15,11 @@ RUN apt update && apt install -y \
     && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && apt update \
-    && apt install -y postgresql-client-${POSTGRESQL_CLIENT_VERSION} \
+    # Install all PostgreSQL client versions
+    && apt install -y \
+       postgresql-client-15 \
+       postgresql-client-16 \
+       postgresql-client-17 \
     && wget https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian12-x86_64-100.10.0.tgz \
     && tar -xvf mongodb-database-tools-debian12-x86_64-100.10.0.tgz \
     && mv mongodb-database-tools-debian12-x86_64-100.10.0/bin/* /usr/local/bin/ \
@@ -35,4 +38,18 @@ RUN apt update && apt install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT ["migrationdb"]
+# Create an entrypoint script to handle version selection
+RUN echo '#!/bin/sh\n\
+if [ "$POSTGRESQL_CLIENT_VERSION" != "15" ] && [ "$POSTGRESQL_CLIENT_VERSION" != "16" ] && [ "$POSTGRESQL_CLIENT_VERSION" != "17" ]; then\n\
+    echo "Error: POSTGRESQL_CLIENT_VERSION must be 15, 16, or 17"\n\
+    exit 1\n\
+fi\n\
+export PATH="/usr/lib/postgresql/${POSTGRESQL_CLIENT_VERSION}/bin:$PATH"\n\
+# Verify the versions\n\
+pg_dump --version\n\
+pg_restore --version\n\
+# Execute the main command with all arguments\n\
+exec migrationdb "$@"' > /entrypoint.sh \
+    && chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
### Description

This pull request updates the PostgreSQL client handling and introduces an entrypoint script to improve flexibility and compatibility:

- Sets the default PostgreSQL client version to 15.
- Installs PostgreSQL client versions 15, 16, and 17 for broader compatibility.
- Adds an entrypoint script to validate the client version and dynamically update the `PATH`.
- Ensures robust error handling and seamless execution of `pg_dump` and `pg_restore` commands.

### Checklist

- [ ] Code builds correctly
- [ ] Tests for the changes have been added (if applicable)
- [ ] Documentation has been updated (if